### PR TITLE
fix(api): return 200 (not 204) with JSON on brandkit delete

### DIFF
--- a/api/src/routes/brandkits.ts
+++ b/api/src/routes/brandkits.ts
@@ -224,7 +224,7 @@ router.delete('/:id', async (req: Request, res: Response<ApiResponse<void>>) => 
     
     brandkits.delete(id);
     
-    res.status(204).json({
+    res.status(200).json({
       success: true,
       timestamp: new Date().toISOString(),
     });


### PR DESCRIPTION
Returning a JSON body with HTTP 204 is invalid. Switch to 200 and include a success payload.