### PR TITLE
fix(backend): BaseDB context types + add requests dependency

### DIFF
--- a/backend/director/db/base.py
+++ b/backend/director/db/base.py
@@ -46,15 +46,23 @@ class BaseDB(ABC):
         pass
 
     @abstractmethod
-    def get_context_messages(self, session_id: str) -> list:
-        """Get context messages for a session."""
+    def get_context_messages(self, session_id: str) -> dict:
+        """Get context messages for a session.
+
+        Should return a dict payload (e.g., {"reasoning": [...]}) suitable for
+        `Session.get_context_messages()` which accesses `.get("reasoning", [])`.
+        """
         pass
 
     @abstractmethod
     def add_or_update_context_msg(
-        self, session_id: str, context_messages: list
+        self, session_id: str, context_messages: dict
     ) -> None:
-        """Update context messages for a session."""
+        """Update context messages for a session.
+
+        Expects a dict payload (for example: {"reasoning": [...]}) which will be
+        stored in the DB as JSON.
+        """
         pass
 
     @abstractmethod

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic==2.8.2",
     "pydantic-settings==2.4.0",
     "python-dotenv==1.0.1",
+    "requests==2.32.3",
     "videodb",
     "yt-dlp==2024.10.7",
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ replicate==1.0.1
 yt-dlp==2024.10.7
 videodb==0.2.10
 slack_sdk==3.33.2
+requests==2.32.3


### PR DESCRIPTION
Align abstract DB signatures with usage and add missing dependency.

- BaseDB.get_context_messages should return a dict (Session expects ).
- BaseDB.add_or_update_context_msg should accept a dict payload, matching concrete DB implementations.
- Add  to Python deps; widely used across tools (serp, videodb_tool, etc.).

This improves typing consistency and avoids runtime ImportError in fresh environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - なし
- 改善/リファクタ
  - コンテキストメッセージの取り扱いを見直し、より明確な構造化データとして保存・取得するように変更。内部APIの整合性を高め、将来の拡張性と安定性を強化。
- 雑務/Chores
  - 依存関係にHTTPクライアントを追加し、外部サービスとの通信の互換性・信頼性を向上。ビルド設定と要件定義を同期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->