### PR TITLE
chore(api): set status_code in validation error handler

### DIFF
--- a/backend/director/entrypoint/api/errors.py
+++ b/backend/director/entrypoint/api/errors.py
@@ -59,6 +59,6 @@ def handle_validation_exception(error):
     resp.response = json.dumps(
         {"status": "error", "message": str(error), "detail": error.errors()}
     )
-    resp.status = 400
+    resp.status_code = 400
     resp.mimetype = "application/json"
     return resp


### PR DESCRIPTION
Aligns the Pydantic validation error handler to use Response.status_code instead of Response.status for consistency with other handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - バリデーション失敗時のAPIエラーレスポンスにおけるHTTPステータスコードの設定方式を見直し、引き続き400を安定して返すよう改善。返却されるJSON形式は変更ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->